### PR TITLE
Use compression for source archive

### DIFF
--- a/_service
+++ b/_service
@@ -1,11 +1,20 @@
 <services>
   <!-- The copy of this file in the OBS package needs to be manually updated from the one in git repo. -->
-  <service name="obs_scm" mode="manual">
+  <service name="tar_scm" mode="manual">
     <param name="scm">git</param>
     <param name="url">https://github.com/openSUSE/cockpit-tukit.git</param>
     <param name="revision">master</param>
     <param name="versionformat">@PARENT_TAG@~git@TAG_OFFSET@.%h</param>
-    <param name="extract">package-lock.json</param>
+    <param name="changesgenerate">enable</param>
+    <param name="package-meta">yes</param>
+  </service>
+  <service name="recompress" mode="manual">
+    <param name="file">cockpit-tukit*.tar</param>
+    <param name="compression">xz</param>
+  </service>
+  <service name="extract_file" mode="manual">
+    <param name="archive">cockpit-tukit*.tar.xz</param>
+    <param name="files">cockpit-tukit-*/package-lock.json</param>
   </service>
   <service name="node_modules" mode="manual">
     <param name="cpio">node_modules.obscpio</param>
@@ -13,10 +22,9 @@
     <param name="source-offset">1000</param>
   </service>
   <service name="extract_file" mode="manual">
-    <param name="archive">cockpit-tukit*.obscpio</param>
+    <param name="archive">cockpit-tukit*.tar.xz</param>
     <param name="files">cockpit-tukit*/cockpit-tukit.spec.in</param>
     <param name="outfilename">cockpit-tukit.spec</param>
   </service>
   <service name="set_version" mode="manual"/>
-  <service name="tar" mode="buildtime"/>
 </services>

--- a/cockpit-tukit.spec.in
+++ b/cockpit-tukit.spec.in
@@ -22,7 +22,7 @@ Summary: Cockpit module for Transactional Update
 License: LGPL-2.1-or-later
 
 URL: https://github.com/openSUSE/cockpit-tukit
-Source: %{name}-%{version}.tar
+Source: %{name}-%{version}.tar.xz
 Source10:       package-lock.json
 Source11:       node_modules.spec.inc
 %include %_sourcedir/node_modules.spec.inc


### PR DESCRIPTION
Sadly the cpio produced by obs-service-node_modules has gz compressed
tars in it, so xz wouldn't be able to help as much.