### PR TITLE
Mention node_modules.sums in spec sources

### DIFF
--- a/cockpit-tukit.spec.in
+++ b/cockpit-tukit.spec.in
@@ -25,6 +25,7 @@ URL: https://github.com/openSUSE/cockpit-tukit
 Source: %{name}-%{version}.tar.xz
 Source10:       package-lock.json
 Source11:       node_modules.spec.inc
+Source12:       node_modules.sums
 %include %_sourcedir/node_modules.spec.inc
 BuildArch: noarch
 BuildRequires: nodejs-devel


### PR DESCRIPTION
Otherwise factory-auto declines with: Attention, node_modules.sums is
not mentioned in spec files as source or patch.