### PR TITLE
[5.2] Fix pot/po generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ po/$(PACKAGE_NAME).js.pot:
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
+		--package-name=$(PACKAGE_NAME) --msgid-bugs-address=translation@lists.opensuse.org \
 		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx' | grep -v src/lib)
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
@@ -40,8 +41,8 @@ po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@
 
-po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot
-	msgcat --sort-output --output-file=$@ $^
+po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).manifest.pot
+	msgcat --use-first --sort-output --output-file=$@ $^
 
 # Update translations against current PO template
 update-po: po/$(PACKAGE_NAME).pot

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,5 +1,5 @@
-# #-#-#-#-#  tukit.js.pot (Tukit 0.1)  #-#-#-#-#
 # tukit czech translation.
+# Copyright (C) 2022
 # This file is distributed under the same license as the tukit package.
 # Zdenek Kubala <zkubala@suse.com>, 2022.
 #
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: tukit 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-09 09:00+0200\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Zdenek Kubala <zkubala@suse.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Aktivní"
 msgid "Available updates ($0)"
 msgstr "Dostupné aktualizace ($0)"
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr "Zkontrolovat dostupné aktualizace"
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr "Kontroluji se dostupné aktualizace..."
 
@@ -54,7 +54,7 @@ msgstr "Zavřít"
 msgid "Default"
 msgstr "Přednastavená hodnota"
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr "Chyba při hledání dostupných aktualizací: $0"
 
@@ -70,7 +70,7 @@ msgstr "Načítám snapshoty..."
 msgid "Installing updates..."
 msgstr "Instalují se aktualizace..."
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr "Naposledy zkontrolováno: $0"
 
@@ -110,7 +110,7 @@ msgstr "Jsou dostupné bezpečnostní aktualizace"
 msgid "Snapshots & Updates"
 msgstr "Snapshoty a aktualizace"
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr "Softwarové aktualizace"
 
@@ -138,7 +138,7 @@ msgstr "Aktualizovat a restartovat"
 msgid "Update without Reboot"
 msgstr "Aktualizovat bez restartu"
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr "Aktualizace"
 

--- a/po/de.po
+++ b/po/de.po
@@ -1,10 +1,13 @@
-# tukit german translations
+# tukit german translation.
+# Copyright (C) 2022
+# This file is distributed under the same license as the tukit package.
+# Robert Simai <rsimai@suse.com>, 2022.
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: tukit 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 16:41+0200\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: 2022-06-09 13:00+0200\n"
 "Last-Translator: Robert Simai <rsimai@suse.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,11 +37,11 @@ msgstr "Aktiv"
 msgid "Available updates ($0)"
 msgstr "Verfügbare Aktualisierungen ($0)"
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr "Prüfe Aktualisierungen"
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr "Prüfe Aktualisierungen ..."
 
@@ -50,7 +53,7 @@ msgstr "Schließen"
 msgid "Default"
 msgstr "Voreinstellung"
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr "Fehler bei der Überprüfung von Aktualisierungen: $0"
 
@@ -66,7 +69,7 @@ msgstr "Snapshots abrufen..."
 msgid "Installing updates..."
 msgstr "Installiere Aktualisierungen..."
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr "Letzte Überprüfung: $0"
 
@@ -106,7 +109,7 @@ msgstr "Sicherheitsaktualisierungen verfügbar"
 msgid "Snapshots & Updates"
 msgstr "Snapshots & Aktualisierungen"
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr "Softwareaktualisierungen"
 
@@ -134,7 +137,7 @@ msgstr "Aktualisieren und Neustart"
 msgid "Update without Reboot"
 msgstr "Aktualisieren ohne Neustart"
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr "Aktualisierungen"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,14 +1,13 @@
-# #-#-#-#-#  tukit.js.pot (PACKAGE VERSION)  #-#-#-#-#
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# tukit japanese translation.
+# Copyright (C) 2022
+# This file is distributed under the same license as the tukit package.
+# Yasuhiko Kamata <belphegor@belbel.or.jp>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE_VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 16:41+0200\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: 2022-08-06 01:32+0000\n"
 "Last-Translator: Yasuhiko Kamata <belphegor@belbel.or.jp>\n"
 "Language-Team: Japanese <https://l10n.opensuse.org/projects/cockpit-tukit/"
@@ -40,11 +39,11 @@ msgstr "有効"
 msgid "Available updates ($0)"
 msgstr "利用可能な更新 ($0 個)"
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr "更新を確認"
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr "更新を確認しています..."
 
@@ -56,7 +55,7 @@ msgstr "閉じる"
 msgid "Default"
 msgstr "既定値"
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr "更新の確認時にエラーが発生しました: $0"
 
@@ -72,7 +71,7 @@ msgstr "スナップショットを検索しています..."
 msgid "Installing updates..."
 msgstr "更新をインストールしています..."
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr "最終確認: $0"
 
@@ -112,7 +111,7 @@ msgstr "セキュリティ更新が利用できます"
 msgid "Snapshots & Updates"
 msgstr "スナップショットと更新"
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr "ソフトウエア更新"
 
@@ -140,7 +139,7 @@ msgstr "更新して再起動"
 msgid "Update without Reboot"
 msgstr "再起動せずに更新"
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr "更新"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,9 +1,12 @@
-# tukit polish translations
+# tukit polish translation.
+# Copyright (C) 2022
+# This file is distributed under the same license as the tukit package.
+# Jacek Tomasiak <jtomasiak@suse.com>, 2022.
 msgid ""
 msgstr ""
-"Project-Id-Version: tukit 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 16:41+0200\n"
+"Project-Id-Version: tukit\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: 2022-08-05 11:47+0000\n"
 "Last-Translator: Jacek Tomasiak <jtomasiak@suse.com>\n"
 "Language-Team: Polish <https://l10n.opensuse.org/projects/cockpit-tukit/"
@@ -35,11 +38,11 @@ msgstr "Aktywna"
 msgid "Available updates ($0)"
 msgstr "Dostępne aktualizacje ($0)"
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr "Wyszukaj aktualizacje"
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr "Wyszukiwanie aktualizacji..."
 
@@ -51,7 +54,7 @@ msgstr "Zamknij"
 msgid "Default"
 msgstr "Domyślna"
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr "Błąd podczas wyszukiwania aktualizacji: $0"
 
@@ -67,7 +70,7 @@ msgstr "Pobieranie migawek..."
 msgid "Installing updates..."
 msgstr "Instalowanie aktualizacji..."
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr "Ostatnio sprawdzone: $0"
 
@@ -107,7 +110,7 @@ msgstr "Dostępne aktualizacje bezpieczeństwa"
 msgid "Snapshots & Updates"
 msgstr "Migawki i aktualizacje"
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr "Aktualizacje oprogramowania"
 
@@ -135,7 +138,7 @@ msgstr "Zaktualizuj i uruchom ponownie"
 msgid "Update without Reboot"
 msgstr "Zaktualizuj bez ponownego uruchomienia"
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr "Aktualizacje"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,14 +1,13 @@
-# #-#-#-#-#  tukit.js.pot (PACKAGE VERSION)  #-#-#-#-#
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# tukit swedish translation.
+# Copyright (C) 2022
+# This file is distributed under the same license as the tukit package.
+# LUNA JERNBERG <bittin@opensuse.org>, 2022.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE_VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 16:41+0200\n"
+"Project-Id-Version: tukit\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: 2022-08-04 14:08+0000\n"
 "Last-Translator: Luna Jernberg <bittin@opensuse.org>\n"
 "Language-Team: Swedish <https://l10n.opensuse.org/projects/cockpit-tukit/"
@@ -40,11 +39,11 @@ msgstr "Aktiv"
 msgid "Available updates ($0)"
 msgstr "Tillgängliga uppdateringar ($0)"
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr "Sök efter uppdateringar"
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr "Söker efter uppdateringar..."
 
@@ -56,7 +55,7 @@ msgstr "Stäng"
 msgid "Default"
 msgstr "Standard"
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr "Fel vid sökning efter uppdateringar: $0"
 
@@ -73,7 +72,7 @@ msgstr "Hämtar ögonblicksbilder..."
 msgid "Installing updates..."
 msgstr "Installerar uppdateringar..."
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr "Senast kontrollerad: $0"
 
@@ -113,7 +112,7 @@ msgstr "Säkerhetsuppdateringar tillgängliga"
 msgid "Snapshots & Updates"
 msgstr "Ögonblicksbilder och uppdateringar"
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr "Programvaruuppdateringar"
 
@@ -141,7 +140,7 @@ msgstr "Uppdatera och starta om"
 msgid "Update without Reboot"
 msgstr "Uppdatera utan att starta om"
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr "Uppdateringar"
 

--- a/po/tukit.pot
+++ b/po/tukit.pot
@@ -1,22 +1,14 @@
-# #-#-#-#-#  tukit.js.pot (PACKAGE VERSION)  #-#-#-#-#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the tukit package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"#-#-#-#-#  tukit.html.pot (PACKAGE_VERSION)  #-#-#-#-#\n"
-"Project-Id-Version: PACKAGE_VERSION\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Cockpit html2po\n"
-"#-#-#-#-#  tukit.js.pot (PACKAGE VERSION)  #-#-#-#-#\n"
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 16:41+0200\n"
+"Project-Id-Version: tukit\n"
+"Report-Msgid-Bugs-To: translation@lists.opensuse.org\n"
+"POT-Creation-Date: 2022-08-09 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,12 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"#-#-#-#-#  tukit.manifest.pot (PACKAGE_VERSION)  #-#-#-#-#\n"
-"Project-Id-Version: PACKAGE_VERSION\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Cockpit manifest2po\n"
 
 #: src/components/SnapshotItem.js:161
 msgid "Activate and Reboot"
@@ -51,11 +37,11 @@ msgstr ""
 msgid "Available updates ($0)"
 msgstr ""
 
-#: src/components/UpdatesPanel.js:160
+#: src/components/UpdatesPanel.js:163
 msgid "Check for Updates"
 msgstr ""
 
-#: src/components/UpdatesPanel.js:108
+#: src/components/UpdatesPanel.js:111
 msgid "Checking for updates..."
 msgstr ""
 
@@ -67,7 +53,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/components/UpdatesPanel.js:122
+#: src/components/UpdatesPanel.js:125
 msgid "Error checking for updates: $0"
 msgstr ""
 
@@ -83,7 +69,7 @@ msgstr ""
 msgid "Installing updates..."
 msgstr ""
 
-#: src/components/UpdatesPanel.js:145
+#: src/components/UpdatesPanel.js:148
 msgid "Last Checked: $0"
 msgstr ""
 
@@ -123,7 +109,7 @@ msgstr ""
 msgid "Snapshots & Updates"
 msgstr ""
 
-#: src/index.html:20 src/manifest.json:0
+#: src/index.html:20
 msgid "Software Updates"
 msgstr ""
 
@@ -151,7 +137,7 @@ msgstr ""
 msgid "Update without Reboot"
 msgstr ""
 
-#: src/components/UpdatesPanel.js:138
+#: src/components/UpdatesPanel.js:141
 msgid "Updates"
 msgstr ""
 


### PR DESCRIPTION
Avoid metadata conflicts. Fill some known metadata. Update existing po
files to match. Reorder pot files to prefer JS input.
    
(cherry picked from commit 252ecf7131dee1aff0ab9f32f923492010f68e73)
