### PR TITLE
Add mapping for more patch levels

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -26,8 +26,8 @@ import {
 } from "@patternfly/react-icons";
 
 export const kindPrio = { patch: 0, package: 1 };
-export const categoryPrio = { security: 0, recommended: 2 };
-export const severityPrio = { important: 0, moderate: 1 };
+export const categoryPrio = { security: 0, recommended: 1, feature: 2 };
+export const severityPrio = { critical: 0, important: 1, moderate: 2 };
 const prioLabelColor = { 0: "red", 1: "blue", 2: "auto" };
 const prioIcon = {
     0: <ExclamationCircleIcon />,


### PR DESCRIPTION
Some patch severity and category values were not included in the mappings.

Before:
![obraz](https://user-images.githubusercontent.com/2458112/196899124-64d60bd2-879a-487d-a1a0-4d2d48d41a8f.png)

After:
![obraz](https://user-images.githubusercontent.com/2458112/196898920-0e2595c0-c9d1-4755-a6e9-81b5e71d1f84.png)
