### PR TITLE
[5.2] Fix name in metainfo (bsc#1203653)

### DIFF
--- a/org.cockpit-project.tukit.metainfo.xml
+++ b/org.cockpit-project.tukit.metainfo.xml
@@ -10,5 +10,5 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">tukit</launchable>
+  <launchable type="cockpit-manifest">updates</launchable>
 </component>


### PR DESCRIPTION
Some parts of cockpit (e.g. launch() in apps) use this value to generate
URLs using cockpit.jump(). As cockpit-tukit runs under /updates, the
metainfo needs to match that.

(cherry picked from commit https://github.com/openSUSE/cockpit-tukit/commit/bdbc821a3d563d370cf776575a8cee19f2816d26)