### PR TITLE
Superuser reload

### DIFF
--- a/src/components/UpdatesPanel.tsx
+++ b/src/components/UpdatesPanel.tsx
@@ -61,6 +61,7 @@ const flattenXMLData = (data: XMLElement, prefix = ""): Update => {
 
 type UpdatesPanelProps = {
 	dirty: boolean;
+	adminAccess: boolean;
 	waiting: string | null;
 	setUpdates: (updates: Update[]) => void;
 	setError: (error: string | null) => void;
@@ -69,6 +70,7 @@ type UpdatesPanelProps = {
 };
 
 const UpdatesPanel = ({
+	adminAccess,
 	setUpdates,
 	setError,
 	dirty,
@@ -173,7 +175,7 @@ const UpdatesPanel = ({
 						<Button
 							variant="primary"
 							isLoading={!!waiting}
-							isDisabled={!!waiting}
+							isDisabled={!adminAccess || !!waiting}
 							onClick={() => {
 								setDirty(true);
 							}}

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -1,0 +1,5 @@
+import type { Superuser } from "superuser";
+
+declare module "hooks" {
+	function useEvent(obj: Superuser, event: "changed"): void;
+}

--- a/types/superuser.d.ts
+++ b/types/superuser.d.ts
@@ -1,0 +1,8 @@
+declare module "superuser" {
+	type Superuser = {
+		allowed: boolean | null;
+		reload_page_on_change(): void;
+	};
+
+	const superuser: Superuser;
+}


### PR DESCRIPTION
Currently `cockpit-tukit` requires manual reload when user gets admin access.
This PR aims to fix that by auto refreshing the content based on the users access rights using cockpit's `superuser` API.