### PR TITLE
Updated minimum cockpit-devel version

### DIFF
--- a/cockpit-tukit.spec.in
+++ b/cockpit-tukit.spec.in
@@ -30,7 +30,7 @@ Source12:       node_modules.sums
 Patch0:         load-css-overrides.patch
 BuildArch:      noarch
 BuildRequires:  appstream-glib
-BuildRequires:  cockpit-devel >= 251
+BuildRequires:  cockpit-devel >= 293
 BuildRequires:  local-npm-registry
 BuildRequires:  make
 BuildRequires:  nodejs-devel


### PR DESCRIPTION
The old minimum version 251 doesn't include the required files to build the updated cockpit-tukit.