### PR TITLE
Forcefully reload the whole page when getting/limitin admin access

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -52,6 +52,8 @@ import { Update } from "./update";
 
 const _ = cockpit.gettext;
 
+superuser.reload_page_on_change();
+
 const Application = () => {
 	const [status, setStatus] = useState<Status[]>([]);
 
@@ -82,7 +84,6 @@ const Application = () => {
 
 	// forward status to Cockpit
 	useEffect(() => {
-		console.log("Forwarding page status");
 		if (status.length > 0) {
 			// page_status can show only one status
 			// use most important one

--- a/src/components/StatusPanel.tsx
+++ b/src/components/StatusPanel.tsx
@@ -62,7 +62,6 @@ const StatusPanel = ({
 }: StatusPanelProps) => {
 	// update page status
 	useEffect(() => {
-		console.log("Updating page status");
 		if (waiting) {
 			setStatus([
 				{


### PR DESCRIPTION
This fixes the issue where user isn't always able to fetch snapshots and updates after getting Administrative access without manually reloading the page