### PR TITLE
Misc: Add Plural-Forms header to zh_TW.po

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -15,6 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/components/SnapshotItem.tsx:168
 msgid "Activate and Reboot"


### PR DESCRIPTION
I spoke to Julia Faltenbacher from the Localisation team, the general consensus is that we can just add `"Plural-Forms: nplurals=1; plural=0;\n"`. There are other examples of the same

- https://github.com/openSUSE/packages-i18n/blob/0fd0ca714df9b1620a845477585e9f1441d018bc/zh_TW/po/patterns.zh_TW.po#L14
- https://github.com/openSUSE/barrel/blob/09c8ca233bd5a18be5f76505bd710fc28c814ce2/po/zh_TW.po#L20 
