### PR TITLE
Add esbuild-wasm as a dependency. Fixes 169

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@patternfly/react-icons": "6.4.0",
         "@patternfly/react-styles": "6.4.0",
         "dequal": "^2.0.3",
+        "esbuild-wasm": "^0.27.2",
         "glob": "^13.0.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -3676,6 +3677,18 @@
       "peerDependencies": {
         "esbuild": ">=0.27.2",
         "sass-embedded": "^1.97.2"
+      }
+    },
+    "node_modules/esbuild-wasm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.2.tgz",
+      "integrity": "sha512-eUTnl8eh+v8UZIZh4MrMOKDAc8Lm7+NqP3pyuTORGFY1s/o9WoiJgKnwXy+te2J3hX7iRbFSHEyig7GsPeeJyw==",
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "qunit": "^2.25.0",
     "sass": "^1.61.0",
     "sizzle": "^2.3.3",
-    "ts-loader": "^9.5.4",
     "stylelint": "16.26.1",
     "stylelint-config-recommended-scss": "16.0.2",
     "stylelint-config-standard": "39.0.1",
     "stylelint-config-standard-scss": "16.0.0",
     "stylelint-formatter-pretty": "4.0.1",
+    "ts-loader": "^9.5.4",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
@@ -59,6 +59,7 @@
     "@patternfly/react-icons": "6.4.0",
     "@patternfly/react-styles": "6.4.0",
     "dequal": "^2.0.3",
+    "esbuild-wasm": "^0.27.2",
     "glob": "^13.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
This was caused when the build.js was updated specifically the useWasm section which tries to use esbuild-wasm on any arch that's not x86. All it needed was the extra dep added in: https://github.com/openSUSE/cockpit-tukit/blob/master/build.js#L16